### PR TITLE
Add Options Indexes to Apache configs

### DIFF
--- a/src/install-Apache2.sh
+++ b/src/install-Apache2.sh
@@ -2,3 +2,12 @@
 # Apache2
 echo ServerName localhost >> /etc/apache2/apache2.conf
 a2enmod rewrite
+
+cd /etc/apache2/sites-enabled
+
+sed -i '29i <Directory /var/www/html>' 000-default.conf
+sed -i '30i        Options Indexes FollowSymLinks MultiViews' 000-default.conf
+sed -i '31i        AllowOverride All' 000-default.conf
+sed -i '32i </Directory>' 000-default.conf
+
+apache2ctl restart

--- a/src/switchhttps.sh
+++ b/src/switchhttps.sh
@@ -10,7 +10,7 @@ openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj \
     -keyout ./ssl.key -out ./ssl.crt
 cd ../sites-enabled
 
-sed -i '131i <Directory /var/www/html/code/*>' default-ssl.conf
+sed -i '131i <Directory /var/www/html>' default-ssl.conf
 sed -i '132i        Options Indexes FollowSymLinks MultiViews' default-ssl.conf
 sed -i '133i        AllowOverride All' default-ssl.conf
 sed -i '134i </Directory>' default-ssl.conf


### PR DESCRIPTION
I've modified `install-Apache2.sh` and added a `<Directory>` directive for `/var/www/html` that enables a few options, most notably `Indexes`, so students do not get a "403 Forbidden" error when opening http://localhost:8080 anymore. Instead, they will see the directory listing so they can click through to their projects in the `webapp` directory.

I've also modified `switchhttps.sh`. There, such a `<Directory>` directive did already exist for HTTPS connections, but it was set for the directory `/var/www/html/code/*`. Probably a remnant of the fhooe-webdev projects. I've changed this to `/var/www/html` so it works for https://localhost:7443 as well.

@martinharrer, please look at the proposed changes and merge them if you find that this suits the project.