### PR TITLE
Add locales and enable gettext support in PHP and in Debian

### DIFF
--- a/Dockerfile-php
+++ b/Dockerfile-php
@@ -11,6 +11,8 @@ RUN apt-get update -y \
 						  libjpeg62-turbo-dev \
 		                  libpng-dev \
                           libpq-dev \
+						  locales \
+						  locales-all \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo pdo_pgsql pgsql \
     && docker-php-ext-install pdo_mysql \
@@ -28,3 +30,7 @@ RUN apt-get update -y \
     && /src/install-PHP+Tools.sh \
 	&& /src/install-Apache2.sh \
     && /src/switchhttps.sh
+# Set environment variables
+ENV LC_ALL en_US.utf8
+ENV LANG en_US.utf8
+ENV LANGUAGE en_US.utf8

--- a/Dockerfile-php
+++ b/Dockerfile-php
@@ -13,6 +13,7 @@ RUN apt-get update -y \
                           libpq-dev \
 						  locales \
 						  locales-all \
+						  gettext \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo pdo_pgsql pgsql \
     && docker-php-ext-install pdo_mysql \

--- a/Dockerfile-php
+++ b/Dockerfile-php
@@ -13,6 +13,7 @@ RUN apt-get update -y \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl \
+	&& docker-php-ext-install gettext \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
 	&& docker-php-ext-install -j$(nproc) gd \
 	&& pecl install xdebug \


### PR DESCRIPTION
I've modified the Dockerfile for the PHP image to install locales and gettext for PHP and the system. Enviroment variables set the default locale to `en_US.utf8` (but can, of course, easily be changed if desired).
I decided to install all locales (not just English and German) because the `locales-all` package has them all precompiled (which is not slower than compiling single languages). Students can also use the container to work with other languages, which might benefit non-German-speaking students.

I've tested my i18n examples, and they all work as expected.

Please check and merge if no issues occur.

This PR closes #2.