### PR TITLE
1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.3.1] - 2026/03/10
+
+### Fixed
+
+- Fixed the database privilege script not running under macOS since execute permissions were not set automatically. Database initialization has been moved to the image and is no longer mounted as a volume.
+
 ## [1.3.0] - 2026/03/04
 
 ### Added
@@ -138,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional tools and configuration for each container: Linux command line tools, Composer, PHP_CS, Xdebug, GitHub CLI
 - Experimental Ubuntu container for shell exercises.
 
-[Unreleased]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.0...HEAD
+[Unreleased]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.1...HEAD
+[1.3.1]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.2.1...1.3.0
 [1.2.1]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.1.2...1.2.0

--- a/Dockerfile-mariadb
+++ b/Dockerfile-mariadb
@@ -11,9 +11,11 @@ LABEL maintainer="Hochleitner, Wolfgang <wolfgang.hochleitner@fh-hagenberg.at>" 
       org.opencontainers.image.title="fhooe-web-dock MariaDB" \
       org.opencontainers.image.description="MariaDB image of the fhooe-web-dock environment"
 
-# Copy additional intialization scripts to the image
+# Copy additional initialization scripts and DB init
 COPY src /src
+COPY init/01_grant_global_access.sh /docker-entrypoint-initdb.d/01_grant_global_access.sh
 
-# Run initialization scripts
+# Run initialization scripts;
 RUN chmod 755 -- /src/*.sh \
+    && chmod +x /docker-entrypoint-initdb.d/01_grant_global_access.sh \
     && /src/install-cli-tools.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,6 @@ services:
       dockerfile: Dockerfile-mariadb
     container_name: mariadb
     volumes:
-      - ./init:/docker-entrypoint-initdb.d
       - dbdata:/var/lib/mysql
     # Values for environment variables are stored in .env file
     environment:

--- a/init/01_grant_global_access.sh
+++ b/init/01_grant_global_access.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Root can connect without password via Unix socket during init (MYSQL_ROOT_PASSWORD is not exported when using MYSQL_RANDOM_ROOT_PASSWORD)
-mariadb -u root <<-EOSQL
+# Root password is required: init scripts run after the entrypoint has set it (no socket auth in this image).
+mariadb -u root -p"$MARIADB_ROOT_PASSWORD" <<-EOSQL
     GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%';
     FLUSH PRIVILEGES;
 EOSQL

--- a/init/01_grant_global_access.sh
+++ b/init/01_grant_global_access.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-mariadb -u root -p"$MYSQL_ROOT_PASSWORD" <<-EOSQL
+# Root can connect without password via Unix socket during init (MYSQL_ROOT_PASSWORD is not exported when using MYSQL_RANDOM_ROOT_PASSWORD)
+mariadb -u root <<-EOSQL
     GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%';
     FLUSH PRIVILEGES;
 EOSQL


### PR DESCRIPTION
### Fixed

- Fixed the database privilege script not running under macOS since execute permissions were not set automatically. Database initialization has been moved to the image and is no longer mounted as a volume.