### PR TITLE
Quickfix for git pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.3.2] - 2026/03/12
+
+### Fixed
+
+- Fixed `CleanReinstall.bat` and `CleanReinstall.sh` so that they work correctly either when the *fhooe-web-dock* directory is not a git directory (e.g., when downloaded as a zip file) or when git is not available on the system. Thank you, [@oliver-krauss](https://github.com/oliver-krauss).
+
 ## [1.3.1] - 2026/03/10
 
 ### Fixed
@@ -144,7 +150,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional tools and configuration for each container: Linux command line tools, Composer, PHP_CS, Xdebug, GitHub CLI
 - Experimental Ubuntu container for shell exercises.
 
-[Unreleased]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.1...HEAD
+[Unreleased]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.2...HEAD
+[1.3.2]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.2.1...1.3.0
 [1.2.1]: https://github.com/Digital-Media/fhooe-web-dock/compare/1.2.0...1.2.1

--- a/CleanReinstall.bat
+++ b/CleanReinstall.bat
@@ -71,7 +71,20 @@ echo Remove any dangling images related to this project
 docker image prune --force --filter "label=com.docker.compose.project=%COMPOSE_PROJECT_NAME%"
 
 echo Update fhooe-web-dock from GitHub
+where git >nul 2>&1
+if errorlevel 1 (
+    echo Skipping git pull ^(git not available^).
+    echo To get updates, download the latest version from https://github.com/Digital-Media/fhooe-web-dock
+    goto afterpull
+)
+git rev-parse --git-dir >nul 2>&1
+if errorlevel 1 (
+    echo Skipping git pull ^(not a git repository^).
+    echo To get updates, download the latest version from https://github.com/Digital-Media/fhooe-web-dock
+    goto afterpull
+)
 git pull
+:afterpull
 
 echo Build the images from scratch
 docker compose %PROFILE_ARG% build --no-cache

--- a/CleanReinstall.sh
+++ b/CleanReinstall.sh
@@ -73,7 +73,15 @@ echo "Remove any dangling images related to this project"
 docker image prune --force --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME"
 
 echo "Update fhooe-web-dock from GitHub"
-git pull
+if ! command -v git &>/dev/null; then
+    echo "Skipping git pull (git not available)."
+    echo "To get updates, download the latest version from https://github.com/Digital-Media/fhooe-web-dock"
+elif ! git rev-parse --git-dir &>/dev/null; then
+    echo "Skipping git pull (not a git repository)."
+    echo "To get updates, download the latest version from https://github.com/Digital-Media/fhooe-web-dock"
+else
+    git pull
+fi
 
 echo "Build the images from scratch"
 docker compose $PROFILE_ARG build --no-cache

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ chmod -R 777 your/directory/within/webapp
 
 Be advised that 777 permissions (read/write/execute for everyone) should never be used on production systems (which *fhooe-web-dock* isn't per definition).
 
+## Troubleshooting
+
+### "Access denied" for user `dbuser` in IntelliJ (or other clients)
+
+If the connection to the database **succeeds** but you get errors like *"Access denied for user 'dbuser'@'%' to database 'DATABASENAME'"* when running SQL (e.g. `DROP DATABASE`, `CREATE DATABASE`, or using other databases), the cause is usually that the **database volume already existed** from an earlier run. Scripts in `init/` (including the one that grants `dbuser` full access) run **only when the database is first created**. If the volume was left over from a previous semester or an older setup, those scripts are skipped and `dbuser` keeps only the default privileges (e.g. only on the `default` database).
+
+**Fix:** Remove the database volume and start again so the init scripts run: `./CleanReinstall.sh` (macOS/Linux) or `CleanReinstall.bat` (Windows) and choose to **delete** the database when asked.
+
 ## Additional Information
 
 Do you need help with *fhooe-web-dock*? Check the [wiki](https://github.com/Digital-Media/fhooe-web-dock/wiki) for known solutions or open an [issue](https://github.com/Digital-Media/fhooe-web-dock/issues).


### PR DESCRIPTION
The CleanReinstall script does not work if git is not available or if this was downloaded as a zip. This is a tiny fix for this.